### PR TITLE
Union Types for Actions / Alerts

### DIFF
--- a/src/AlertQueue.ts
+++ b/src/AlertQueue.ts
@@ -1,10 +1,10 @@
 import { Dispatch, useContext, useEffect, useState } from 'react';
 import AppContext from './AppContext';
-import { AlertQueueEvent } from './components/alerts/types';
+import { AllAlerts } from './components/alerts/types';
 
-export function useAlertQueue(dispatch: Dispatch<any>): AlertQueueEvent | null {
+export function useAlertQueue(dispatch: Dispatch<any>): AllAlerts | null {
   const ctx = useContext(AppContext);
-  const [currentAlert, setCurrentAlert] = useState<AlertQueueEvent | null>(null);
+  const [currentAlert, setCurrentAlert] = useState<AllAlerts | null>(null);
 
   useEffect(() => {
     if (ctx.state.alerts.length === 0) setCurrentAlert(null);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,13 +15,13 @@ interface AppProps {
   uri: string | undefined;
 }
 
+const initialState: AppState = {
+  chatMessages: [],
+  alerts: [],
+};
+
 function App(props: AppProps) {
   const { uri } = props;
-
-  const initialState: AppState = {
-    chatMessages: [],
-    alerts: [],
-  };
 
   const [state, dispatch] = useReducer(AppReducer, initialState);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import Overlay from './components/overlay';
 import Webcam from './components/webcam';
 import { GlobalStyle } from './styles';
 import { MainframeEvent, ChatWebsocketEvent, AlertWebsocketEvent } from './types';
+import { AlertNames } from './components/alerts/types';
 
 interface AppProps {
   uri: string | undefined;
@@ -16,6 +17,13 @@ interface AppProps {
 
 function App(props: AppProps) {
   const { uri } = props;
+
+  const initialState: AppState = {
+    chatMessages: [],
+    alerts: [],
+  };
+
+  const [state, dispatch] = useReducer(AppReducer, initialState);
 
   useEffect(() => {
     let socket: any;
@@ -26,60 +34,54 @@ function App(props: AppProps) {
 
       socket.on(MainframeEvent.chatmessage, (event: ChatWebsocketEvent) => {
         dispatch({
-          type: 'addChatMessage',
+          type: MainframeEvent.addChatMessage,
           data: event.data,
         });
       });
 
       socket.on(MainframeEvent.raid, (event: AlertWebsocketEvent) => {
-        const dataToPass: any = {
-          type: MainframeEvent.raid,
-          id: event.id,
-          data: event.data,
-        };
-
         dispatch({
           type: MainframeEvent.raid,
-          data: dataToPass,
+          data: {
+            type: AlertNames.Raid,
+            id: event.id,
+            data: event.data as any, 
+            // ^ those are currently the only places we need to trust the server
+            // TODO maybe add type guards on future refactorings
+          }
         });
       });
 
       socket.on(MainframeEvent.sub, (event: AlertWebsocketEvent) => {
-        const dataToPass: any = {
-          type: MainframeEvent.sub,
-          id: event.id,
-          data: event.data,
-        };
-
         dispatch({
           type: MainframeEvent.sub,
-          data: dataToPass,
+          data: {
+            type: AlertNames.Sub,
+            id: event.id,
+            data: event.data as any,
+          },
         });
       });
 
       socket.on(MainframeEvent.cheer, (event: AlertWebsocketEvent) => {
-        const dataToPass: any = {
-          type: MainframeEvent.cheer,
-          id: event.id,
-          data: event.data,
-        };
-
         dispatch({
           type: MainframeEvent.cheer,
-          data: dataToPass,
+          data: {
+            type: AlertNames.Cheer,
+            id: event.id,
+            data: event.data as any,
+          }
         });
       });
 
       socket.on(MainframeEvent.follow, (event: AlertWebsocketEvent) => {
-        const dataToPass: any = {
-          type: MainframeEvent.follow,
-          id: event.id,
-          data: event.data,
-        };
-
         dispatch({
           type: MainframeEvent.follow,
-          data: dataToPass,
+          data: {  
+            type: AlertNames.Follow,  // now that actions are typed, this has also the right type ;)
+            id: event.id,
+            data: event.data as any,
+          },
         });
       });
     }
@@ -90,13 +92,6 @@ function App(props: AppProps) {
       }
     };
   }, [uri]);
-
-  const initialState: AppState = {
-    chatMessages: [],
-    alerts: [],
-  };
-
-  const [state, dispatch] = useReducer(AppReducer, initialState);
 
   return (
     <AppContext.Provider value={{ state, dispatch }}>

--- a/src/AppContext.ts
+++ b/src/AppContext.ts
@@ -1,5 +1,5 @@
 import { createContext, Dispatch } from 'react';
-import type { AlertQueueEvent, AllAlerts } from './components/alerts/types';
+import type { AllAlerts } from './components/alerts/types';
 import type { ChatMessageEvent } from './components/chat/types';
 
 export interface AppState {

--- a/src/AppContext.ts
+++ b/src/AppContext.ts
@@ -1,10 +1,10 @@
 import { createContext, Dispatch } from 'react';
-import type { AlertQueueEvent } from './components/alerts/types';
+import type { AlertQueueEvent, AllAlerts } from './components/alerts/types';
 import type { ChatMessageEvent } from './components/chat/types';
 
 export interface AppState {
   chatMessages: ChatMessageEvent[];
-  alerts: AlertQueueEvent[];
+  alerts: AllAlerts[];
 }
 
 interface AppContextProps {

--- a/src/AppReducer.ts
+++ b/src/AppReducer.ts
@@ -1,25 +1,16 @@
 import type { AppState } from './AppContext';
-import type { ChatMessageEvent } from './components/chat/types';
-import type { AlertQueueEvent } from './components/alerts/types';
 import { MaxMessageCount } from './components/chat';
-import { MainframeEvent } from './types';
+import { AllActions, MainframeEvent } from './types';
 import { getTeamMemberIconUrl } from './components/chat/message/utils';
 
-interface AppAction {
-  type: string;
-  data: AlertQueueEvent | ChatMessageEvent;
-}
-
-export default function AppReducer(state: AppState, action: AppAction) {
+export default function AppReducer(state: AppState, action: AllActions) {
   const newState = { ...state };
 
   switch (action.type) {
-    case 'addChatMessage':
-      (action.data as ChatMessageEvent).teamMemberIconUrl = getTeamMemberIconUrl(
-        (action.data as ChatMessageEvent).isTeamMember,
-      );
+    case MainframeEvent.addChatMessage:
+      action.data.teamMemberIconUrl = getTeamMemberIconUrl(action.data.isTeamMember);
 
-      newState.chatMessages.push(action.data as ChatMessageEvent);
+      newState.chatMessages.push(action.data);
 
       if (newState.chatMessages.length > MaxMessageCount) {
         newState.chatMessages.shift();
@@ -30,10 +21,10 @@ export default function AppReducer(state: AppState, action: AppAction) {
     case MainframeEvent.raid:
     case MainframeEvent.cheer:
     case MainframeEvent.sub:
-      if (!newState.alerts.some((alert) => alert.data.id === action.data.id)) {
-        newState.alerts.push(action.data as AlertQueueEvent);
+      if (!newState.alerts.some((alert) => alert.id === action.data.id)) {
+        newState.alerts.push(action.data);
       }
-      return { ...newState };
+      return { ...newState }; // << negue: this will be refactored / improved
     case 'alert_complete':
       newState.alerts.shift();
       return { ...newState };

--- a/src/components/alerts/debug.ts
+++ b/src/components/alerts/debug.ts
@@ -1,15 +1,45 @@
-export const debugAlert = {
-  type: 'cheer',
+import { AlertNames, CheerAlert, FollowAlert, RaidAlert, SubAlert } from "./types";
+
+export const debugCheerAlert: CheerAlert = {
+  type: AlertNames.Cheer,
   id: Date.now().toString(),
   data: {
     cheererName: 'Mystery cheerer',
     logoUrl:
       'https://static-cdn.jtvnw.net/jtv_user_pictures/69ade2a2-82e1-477c-afc6-43582bf2844c-profile_image-300x300.png',
     bitCount: 1000,
+  },
+};
+
+export const debugFollowAlert: FollowAlert = {
+  type: AlertNames.Follow,
+  id: Date.now().toString(),
+  data: {
+    logoUrl:
+      'https://static-cdn.jtvnw.net/jtv_user_pictures/69ade2a2-82e1-477c-afc6-43582bf2844c-profile_image-300x300.png',
     followerUserId: '123',
     followerName: 'Test follower',
+  },
+};
+
+export const debugRaidAlert: RaidAlert = {
+  type: AlertNames.Raid,
+  id: Date.now().toString(),
+  data: {
+    logoUrl:
+      'https://static-cdn.jtvnw.net/jtv_user_pictures/69ade2a2-82e1-477c-afc6-43582bf2844c-profile_image-300x300.png',
     raiderCount: 1000,
     raider: 'Mystery raider',
+  },
+};
+
+
+export const debugSubAlert: SubAlert = {
+  type: AlertNames.Sub,
+  id: Date.now().toString(),
+  data: {
+    logoUrl:
+      'https://static-cdn.jtvnw.net/jtv_user_pictures/69ade2a2-82e1-477c-afc6-43582bf2844c-profile_image-300x300.png',
     subscriberUsername: 'Mystery subscriber',
     subTier: '3',
     message: 'Test message',

--- a/src/components/alerts/index.tsx
+++ b/src/components/alerts/index.tsx
@@ -82,7 +82,7 @@ function getAlertAudioUrl(type: string) {
 export default function Alert(props: AlertProps) {
   const debug = false;
   let alert = useAlertQueue(props.dispatch);
-  if (debug){
+  if (debug) {
     alert = debugCheerAlert;
   }
 

--- a/src/components/alerts/index.tsx
+++ b/src/components/alerts/index.tsx
@@ -9,7 +9,7 @@ import {
 } from './index.style';
 import BannerImage from './svg/bannerImage';
 import BannerTextPath from './svg/bannerTextPath';
-import { AlertNames, AlertQueueEvent, AllAlerts } from './types';
+import { AlertNames, AllAlerts } from './types';
 import { useAlertQueue } from '../../AlertQueue';
 import { debugCheerAlert } from './debug';
 

--- a/src/components/alerts/index.tsx
+++ b/src/components/alerts/index.tsx
@@ -9,17 +9,18 @@ import {
 } from './index.style';
 import BannerImage from './svg/bannerImage';
 import BannerTextPath from './svg/bannerTextPath';
-import { AlertNames } from './types';
+import { AlertNames, AlertQueueEvent, AllAlerts } from './types';
 import { useAlertQueue } from '../../AlertQueue';
-import { debugAlert } from './debug';
+import { debugCheerAlert } from './debug';
 
 interface AlertProps {
   dispatch: Dispatch<any>;
 }
 
-function getBannerText(alert: any): any {
+function getBannerText(alert: AllAlerts): any {
   switch (alert.type) {
     case AlertNames.Follow:
+      
       return {
         banner: 'New follower',
         footer: alert.data.followerName,
@@ -81,9 +82,12 @@ function getAlertAudioUrl(type: string) {
 export default function Alert(props: AlertProps) {
   const debug = false;
   let alert = useAlertQueue(props.dispatch);
-  if (debug) alert = debugAlert;
+  if (debug){
+    alert = debugCheerAlert;
+  }
+
   if (!alert) return null;
-  const displayText = debug ? getBannerText(debugAlert) : getBannerText(alert);
+  const displayText = getBannerText(alert);
   const alertAudioUrl = getAlertAudioUrl(alert.type);
 
   return (

--- a/src/components/alerts/types.ts
+++ b/src/components/alerts/types.ts
@@ -6,9 +6,8 @@ export enum AlertNames {
 }
 
 export interface AlertQueueEvent {
-  type: string;
+  type: AlertNames;
   id: string;
-  data: { [key: string]: any };
 }
 
 export interface RaidAlert extends AlertQueueEvent {
@@ -38,7 +37,7 @@ export interface CheerAlert extends AlertQueueEvent {
   };
 }
 
-export interface SubAlert {
+export interface SubAlert extends AlertQueueEvent {
   type: AlertNames.Sub;
   data: {
     logoUrl: string;
@@ -48,3 +47,5 @@ export interface SubAlert {
     months: number;
   };
 }
+
+export type AllAlerts = RaidAlert | FollowAlert | CheerAlert | SubAlert;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { ChatMessageEvent } from './components/chat/types';
-import { AlertQueueEvent } from './components/alerts/types';
+import { AlertQueueEvent, AllAlerts } from './components/alerts/types';
 export interface SocketOptions {
   reconnect: boolean;
 }
@@ -13,7 +13,13 @@ export enum MainframeEvent {
   teammemberjoin = 'teammember',
   chatmessage = 'chatmessage',
   follow = 'follow',
+  alert_complete = 'alert_complete',
+
+  addChatMessage = 'addChatMessage'
 }
+
+// TODO split / cleanup WebSocket and App Events / Payload Types
+
 export interface ChatWebsocketEvent {
   broadcaster: string;
   event: MainframeEvent;
@@ -21,12 +27,34 @@ export interface ChatWebsocketEvent {
   data: ChatMessageEvent;
 }
 
+// Usually each Action would be typed with its own type
+// but here each type has the same data type so we'll just use a union type here
+// ALL except addChatMessage for now
+export type AlertEventTypes = Exclude<MainframeEvent, MainframeEvent.addChatMessage>;
+
+
 export interface AlertWebsocketEvent {
   broadcaster: string;
   event: MainframeEvent;
   id: string;
   data: AlertQueueEvent;
 }
+
+export interface AppAction {
+  type: MainframeEvent;
+}
+
+export interface ChatMessageAction extends AppAction {
+  type: MainframeEvent.addChatMessage;
+  data: ChatMessageEvent;
+}
+
+export interface AlertAction extends AppAction {
+  type: AlertEventTypes;
+  data: AllAlerts
+}
+
+export type AllActions = ChatMessageAction | AlertAction;
 
 // eslint-disable-next-line no-unused-vars
 export type Callback = (data: any) => void;


### PR DESCRIPTION
This is the first PR :)

Currently it combines the Alerts and Actions to one union type.

With this union you get all typescript types PER switch-case of the `entry.type` - which removes some `obj as Type` castings
